### PR TITLE
Fix unsupported  "package" parameter of "yum" module and add "regex file" for seek rpm package properly

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,6 +1,6 @@
 - name: ensure rpm-build is installed
   yum:
-    package: 'rpm-build'
+    name: 'rpm-build'
     state: 'present'
   tags: ['efs-utils']
 
@@ -11,8 +11,15 @@
     creates: "{{ efsutils_src_dest }}/build/amazon-efs-utils*rpm"
   tags: ['efs-utils']
 
-- name: use yum to install efs-utils
+- name: locate generated rpm package
+  find:
+    paths: "{{ efsutils_src_dest }}/build"
+    patterns: "amazon-efs-utils.*\\.rpm$"
+    use_regex: yes
+  register: rpm_file
+
+- name: use yum to install amazon-efs-utils package
   yum:
-    name: "{{ efsutils_src_dest }}/build/amazon-efs-utils*rpm"
+    name: "{{ rpm_file.files[0].path }}"
     state: present
   tags: ['efs-utils']


### PR DESCRIPTION
* Fix unsupported  "package" parameter of "yum" module

`{“changed”: false, “msg”: “Unsupported parameters for (ansible.legacy.yum) module: package. Supported parameters include: lock_timeout, conf_file, exclude, allow_downgrade, disable_gpg_check, disable_excludes, use_backend, validate_certs, state, disablerepo, releasever, skip_broken, autoremove, download_dir, name (pkg), installroot, install_weak_deps, update_cache (expire-cache), download_only, bugfix, list, install_repoquery, update_only, disable_plugin, enablerepo, security, enable_plugin.“}`

* Add "regex file" for seek rpm package properly

`Can not find rpm package`
